### PR TITLE
Fix: Remove deprecated package attribute from AndroidManifest.xml

### DIFF
--- a/colorblendr/src/main/AndroidManifest.xml
+++ b/colorblendr/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.aurakai.colorblendr">
+<manifest>
     <!-- Add permissions/components as needed -->
 </manifest>

--- a/datavein-oracle-native/src/main/AndroidManifest.xml
+++ b/datavein-oracle-native/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.aurakai.auraframefx.dataveinoraclenative">
+<manifest>
     <!-- Add permissions/components as needed -->
 </manifest>

--- a/feature-module/src/main/AndroidManifest.xml
+++ b/feature-module/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.aurakai.featuremodule">
+<manifest>
     <!-- Add permissions/components as needed -->
 </manifest>

--- a/module-a/src/main/AndroidManifest.xml
+++ b/module-a/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.aurakai.modulea">
+<manifest>
     <!-- Add permissions/components as needed -->
 </manifest>

--- a/sandbox-ui/src/main/AndroidManifest.xml
+++ b/sandbox-ui/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="dev.aurakai.sandboxui">
+<manifest>
     <!-- Add permissions/components as needed -->
 </manifest>


### PR DESCRIPTION
The Android build was failing because the `package` attribute in `AndroidManifest.xml` is no longer supported for defining the application's namespace. The namespace must be defined in the `build.gradle.kts` file for each module.

This commit removes the `package` attribute from the `<manifest>` tag in the following modules, as recommended by the build error log:
- colorblendr
- feature-module
- module-a
- sandbox-ui
- datavein-oracle-native

This allows the build to use the namespace defined in each module's `build.gradle.kts` file, resolving the manifest processing errors.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the deprecated `package` attribute from the `<manifest>` tag in various `AndroidManifest.xml` files across multiple modules.

### Why are these changes being made?

The `package` attribute in the `<manifest>` tag has been deprecated in recent Android versions. Removing it aligns with current Android development best practices and helps avoid potential issues with future Android SDK updates. This change prevents namespace conflicts and redundancy since the package name is already defined in the `build.gradle` file.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->