### PR TITLE
Fix: Add missing Compose Compiler Gradle plugin

The build was failing for modules using Jetpack Compose with Kotlin 2.0.
This was because the Compose Compiler Gradle plugin, which is required
starting with Kotlin 2.0, was not being applied.

This change addresses the issue by:
1. Exposing the `kotlin-compose` plugin in the root `build.gradle.kts`
   file, making it available to all modules.
2. Applying the `kotlin-compose` plugin to the `collab-canvas` module,
   which was the source of the build failure.

This resolves the build error and allows the project to be built
successfully.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.hilt) apply false // Expose Hilt plugin for convention plugins
     alias(libs.plugins.ksp) apply false // Expose KSP plugin for convention plugins
+    alias(libs.plugins.kotlin.compose) apply false // Expose Compose plugin for convention plugins
 
     // Optional plugins to be applied in specific modules
     alias(libs.plugins.openapi.generator) apply false

--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.library")
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the missing Compose Compiler Gradle plugin to the `build.gradle.kts` file and apply it to the `collab-canvas` module.

### Why are these changes being made?

The build was failing for modules using Jetpack Compose with Kotlin 2.0 due to the missing Compose Compiler Gradle plugin, which is required starting with Kotlin 2.0. By exposing the `kotlin-compose` plugin in the root `build.gradle.kts` file and applying it to the `collab-canvas` module, the build error is resolved, allowing the project to be built successfully.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->